### PR TITLE
Improve regex used in reminders.py

### DIFF
--- a/commands/reminders.py
+++ b/commands/reminders.py
@@ -55,25 +55,17 @@ def parse_time(time):
             pass
 
     if not parsed_time:
-        result = re.match(r"(\d+d)?(?:\s+)?(\d+h)?(?:\s+)?(\d+m)?(?:\s+)?(\d+s)?(?!^)$", time)
+        result = re.match(r"(\d+d)?\s*(\d+h)?\s*(\d+m)?\s*(\d+s)?(?!^)$", time)
         if result:
             parsed_time = now
             if result.group(1):
-                parsed_time = parsed_time + timedelta(
-                    days=int(result.group(1)[:-1])
-                )
+                parsed_time = parsed_time + timedelta(days=int(result.group(1)[:-1]))
             if result.group(2):
-                parsed_time = parsed_time + timedelta(
-                    hours=int(result.group(2)[:-1])
-                )
+                parsed_time = parsed_time + timedelta(hours=int(result.group(2)[:-1]))
             if result.group(3):
-                parsed_time = parsed_time + timedelta(
-                    minutes=int(result.group(3)[:-1])
-                )
+                parsed_time = parsed_time + timedelta(minutes=int(result.group(3)[:-1]))
             if result.group(4):
-                parsed_time = parsed_time + timedelta(
-                    seconds=int(result.group(4)[:-1])
-                )
+                parsed_time = parsed_time + timedelta(seconds=int(result.group(4)[:-1]))
 
     return parsed_time
 

--- a/commands/reminders.py
+++ b/commands/reminders.py
@@ -56,27 +56,25 @@ def parse_time(time):
             pass
 
     if not parsed_time:
-        result = re.match(r"(\d+d)?(\d+h)?(\d+m)?(\d+s)?$", time)
+        result = re.match(r"(\d+d)?(?:\s+)?(\d+h)?(?:\s+)?(\d+m)?(?:\s+)?(\d+s)?(?!^)$", time)
         if result:
-            check_empty = re.match(r"$", time)
-            if not check_empty:
-                parsed_time = now
-                if result.group(1):
-                    parsed_time = parsed_time + timedelta(
-                        days=int(result.group(1)[:-1])
-                    )
-                if result.group(2):
-                    parsed_time = parsed_time + timedelta(
-                        hours=int(result.group(2)[:-1])
-                    )
-                if result.group(3):
-                    parsed_time = parsed_time + timedelta(
-                        minutes=int(result.group(3)[:-1])
-                    )
-                if result.group(4):
-                    parsed_time = parsed_time + timedelta(
-                        seconds=int(result.group(4)[:-1])
-                    )
+            parsed_time = now
+            if result.group(1):
+                parsed_time = parsed_time + timedelta(
+                    days=int(result.group(1)[:-1])
+                )
+            if result.group(2):
+                parsed_time = parsed_time + timedelta(
+                    hours=int(result.group(2)[:-1])
+                )
+            if result.group(3):
+                parsed_time = parsed_time + timedelta(
+                    minutes=int(result.group(3)[:-1])
+                )
+            if result.group(4):
+                parsed_time = parsed_time + timedelta(
+                    seconds=int(result.group(4)[:-1])
+                )
 
     return parsed_time
 


### PR DESCRIPTION
- Allows for spaces between each unit of time
- Removes need for checking nonempty string by using `(?!^)$` at the end
I did not add `flags=re.IGNORECASE` since I decided you hadn't for a good reason.
Same goes for changing `parsed_time = parsed_time + timedelta(...)` to `parsed_time += timedelta(...)`.
Removed line 1 - leftover chaff from import reorganisation?